### PR TITLE
feat(auth): add demo login and deployment env support

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,7 @@
+# Client Environment Variables
+# Copy this to .env and update with your values
+
+# Backend API URL (without trailing slash)
+# For local development: http://localhost:8000
+# For production: https://your-render-app.onrender.com
+VITE_API_URL=http://localhost:8000

--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:8000';
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
 const api = axios.create({
   baseURL: API_BASE_URL,
@@ -22,6 +22,7 @@ api.interceptors.request.use((config) => {
 export const authAPI = {
   register: (email, password) => api.post('/auth/register', { email, password }),
   login: (email, password) => api.post('/auth/login', { email, password }),
+  demoLogin: () => api.post('/auth/demo'),
   logout: () => api.post('/auth/logout'),  // New: calls backend to cleanup session
 };
 

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -16,8 +16,13 @@ export const AuthProvider = ({ children }) => {
     setLoading(false);
   }, [token]);
 
-  const login = async (email, password) => {
-    const response = await authAPI.login(email, password);
+  const login = async (email, password, isDemo = false) => {
+    let response;
+    if (isDemo) {
+      response = await authAPI.demoLogin();
+    } else {
+      response = await authAPI.login(email, password);
+    }
     const { access_token } = response.data;
     localStorage.setItem('token', access_token);
     setToken(access_token);

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { LogIn, Mail, Lock, FileText } from 'lucide-react';
+import { LogIn, Mail, Lock, FileText, Zap } from 'lucide-react';
 import ThemeToggle from '../components/ThemeToggle';
 
 export default function Login() {
@@ -21,6 +21,19 @@ export default function Login() {
       navigate('/dashboard');
     } catch (err) {
       setError(err.response?.data?.detail || 'Login failed. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDemoLogin = async () => {
+    setError('');
+    setLoading(true);
+    try {
+      await login(null, null, true); // true = demo mode
+      navigate('/dashboard');
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Demo login failed.');
     } finally {
       setLoading(false);
     }
@@ -123,6 +136,16 @@ export default function Login() {
                   <span>Sign in</span>
                 </>
               )}
+            </button>
+
+            <button
+              type="button"
+              onClick={handleDemoLogin}
+              disabled={loading}
+              className="w-full py-2.5 sm:py-3 rounded-xl flex items-center justify-center space-x-2 font-semibold text-xs sm:text-sm transition-all duration-300 disabled:opacity-40 border border-[var(--border-light)] hover:border-[var(--accent-primary)] text-[var(--text-primary)]"
+            >
+              <Zap className="h-4 w-4 text-yellow-500" />
+              <span>Try Demo Account</span>
             </button>
           </form>
 

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -14,4 +14,8 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+  },
 })

--- a/server/api/auth.py
+++ b/server/api/auth.py
@@ -42,6 +42,26 @@ def login(data: LoginRequest):
     return {"access_token": token, "token_type": "bearer"}
 
 
+@router.post("/demo")
+def demo_login():
+    """Login with a temporary demo account (auto-created if not exists)"""
+    demo_email = "demo@doctalk.app"
+    demo_password = "Demo@12345"
+
+    user = users_col.find_one({"email": demo_email})
+    if not user:
+        user = {
+            "user_id": str(uuid.uuid4()),
+            "email": demo_email,
+            "password": hash_password(demo_password),
+            "is_demo": True,
+        }
+        users_col.insert_one(user)
+
+    token = create_access_token({"user_id": user["user_id"]})
+    return {"access_token": token, "token_type": "bearer"}
+
+
 @router.post("/logout")
 def logout(user: dict = Depends(get_current_user)):
     """


### PR DESCRIPTION
- POST /auth/demo auto-creates shared demo user
- VITE_API_URL env var replaces hardcoded localhost
- vite build config: outDir dist, no sourcemaps

Closes #3